### PR TITLE
Fix ticket collisions

### DIFF
--- a/rootfs/scripts/lock.sh
+++ b/rootfs/scripts/lock.sh
@@ -15,7 +15,7 @@ cd "$ARG_CHECKOUT_LOCATION"
 
 __mutex_queue_file=mutex_queue
 __repo_url="https://x-access-token:$ARG_REPO_TOKEN@github.com/$ARG_REPOSITORY"
-__ticket_id="$GITHUB_RUN_ID-$(date +%s)"
+__ticket_id="$GITHUB_RUN_ID-$(date +%s)-$(( $RANDOM % 1000 ))"
 echo "::save-state name=ticket_id::$__ticket_id"
 
 set_up_repo "$__repo_url"


### PR DESCRIPTION
When tickets are generated on the same second for the same workflow, there is a ticket collision. Some runs that reflect this behaviour:

- https://github.com/ben-z/gh-action-mutex/actions/runs/2045826722/attempts/3
- https://github.com/ben-z/gh-action-mutex/actions/runs/2045826722/attempts/1

Adding a random number between 0 and 999 should alleviate this. 