### PR TITLE
Use `github.token` by default

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,8 +8,6 @@ jobs:
       - uses: actions/checkout@v3
       - name: Set up mutex
         uses: ./
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - run: |
           echo "I am protected!"
           sleep 5
@@ -24,7 +22,6 @@ jobs:
         uses: ./
         with:
           branch: gh-mutex-two-clients-test
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - run: |
           echo "I am protected! (Client 1)"
           sleep 20
@@ -39,7 +36,6 @@ jobs:
         uses: ./
         with:
           branch: gh-mutex-two-clients-test
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - run: |
           echo "I am protected! (Client 2)"
           sleep 20
@@ -53,7 +49,6 @@ jobs:
       - name: Set up mutex
         uses: ./
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
           debug: "true"
       - run: |
           echo "I am protected!"

--- a/README.md
+++ b/README.md
@@ -14,9 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up mutex
-        uses: ben-z/gh-action-mutex@v1.0-alpha-3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        uses: ben-z/gh-action-mutex@v1.0-alpha-4
       - run: |
           echo "I am protected!"
           sleep 5
@@ -35,14 +33,15 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up mutex
-        uses: ben-z/gh-action-mutex@v1.0-alpha-3
+        uses: ben-z/gh-action-mutex@v1.0-alpha-4
         with:
           branch: another-mutex
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - run: |
           echo "I am protected by the 'another-mutex' mutex!"
           sleep 5
 ```
+
+More options such as using a different repo to store the mutex (which allows sharing a mutex between jobs from arbitrary repos) or using different access tokens can be found in [actions.yml](./actions.yml)
 
 ## Motivation
 

--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,8 @@ description: 'A simple locking/unlocking mechanism to provide mutual exclusion i
 inputs:
   repo-token:
     description: 'The token for accessing the repo.'
-    required: true
+    required: false
+    default: ${{ github.token }}
   repository:
     description: 'The repository path that stores the lock. E.g `ben-z/gh-action-mutex`'
     required: false


### PR DESCRIPTION
Use `github.token` as the default access token so that users don't need to specify it explicitly.

Resolves #3