### PR TITLE
Use alpine as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM ubuntu:20.04
+FROM alpine:3.16
 
-RUN apt-get update && apt-get install -y curl git
+RUN  apk update \
+  && apk add --no-cache bash curl git
 
 COPY rootfs/ /
-


### PR DESCRIPTION
Change the base image to reduce the starting time of this action.

Another option is instead of building the image every time the action is used, start to publish the container image at the [GHCR](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry)
```
 docker image ls|grep gh-action-mutex
local/gh-action-mutex                                     alpine                                                                       7699135c1ed7   23 seconds ago       24.4MB
local/gh-action-mutex                                     ubuntu                                                                       9007fe65ffb2   3 minutes ago        215MB
```