### PR TITLE
Add support for GHES

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ jobs:
 
 More options such as using a different repo to store the mutex (which allows sharing a mutex between jobs from arbitrary repos) or using different access tokens can be found in [action.yml](./action.yml).
 
+### GitHub Enterprise Server
+
+It might be necessary to adjust the GitHub Server URL in case you are using a GitHub Enterprise Server. You can adjust the server URL by providing `github_server` input to the action. Please make sure to not include the `https://`. 
+
 ## Motivation
 
 GitHub Action has the [concurrency](https://docs.github.com/en/actions/using-jobs/using-concurrency) option for preventing running multiple jobs concurrently. However, it has a queue of length 1. When multiple jobs with the same concurrency group get queued, only the currently running job and the latest queued job are kept. Other jobs are simply cancelled. There's more discussion [here](https://github.com/github/feedback/discussions/5435) and it appears that GitHub does not want to add the requested `cancel-pending` feature any time soon (as of 2022-03-26). This GitHub action solves that issue.

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,10 @@ inputs:
     description: 'The token for accessing the repo.'
     required: false
     default: ${{ github.token }}
+  github_server:
+    description: 'The GitHub server URL without `https`. This might be useful for e.g. GHES'
+    required: false
+    default: github.com
   repository:
     description: 'The repository path that stores the lock. E.g `ben-z/gh-action-mutex`'
     required: false
@@ -31,6 +35,7 @@ runs:
   env:
     ARG_BRANCH: ${{ inputs.branch }}
     ARG_CHECKOUT_LOCATION: ${{ inputs.internal_checkout-location }}
+    ARG_GITHUB_SERVER: ${{ inputs.github_server }}
     ARG_REPOSITORY: ${{ inputs.repository }}
     ARG_REPO_TOKEN: ${{ inputs.repo-token }}
     ARG_DEBUG: ${{ inputs.debug }}

--- a/rootfs/scripts/lock.sh
+++ b/rootfs/scripts/lock.sh
@@ -14,7 +14,7 @@ mkdir -p "$ARG_CHECKOUT_LOCATION"
 cd "$ARG_CHECKOUT_LOCATION"
 
 __mutex_queue_file=mutex_queue
-__repo_url="https://x-access-token:$ARG_REPO_TOKEN@github.com/$ARG_REPOSITORY"
+__repo_url="https://x-access-token:$ARG_REPO_TOKEN@$ARG_GITHUB_SERVER/$ARG_REPOSITORY"
 __ticket_id="$GITHUB_RUN_ID-$(date +%s)-$(( $RANDOM % 1000 ))"
 echo "ticket_id=$__ticket_id" >> $GITHUB_STATE
 

--- a/rootfs/scripts/unlock.sh
+++ b/rootfs/scripts/unlock.sh
@@ -12,7 +12,7 @@ mkdir -p "$ARG_CHECKOUT_LOCATION"
 cd "$ARG_CHECKOUT_LOCATION"
 
 __mutex_queue_file=mutex_queue
-__repo_url="https://x-access-token:$ARG_REPO_TOKEN@github.com/$ARG_REPOSITORY"
+__repo_url="https://x-access-token:$ARG_REPO_TOKEN@$ARG_GITHUB_SERVER/$ARG_REPOSITORY"
 __ticket_id="$STATE_ticket_id"
 
 set_up_repo "$__repo_url"


### PR DESCRIPTION
Without that change it's only possible to use `github.com` repositories to hold the lock. If you are using a GitHub enterprise server you aren't able to use this action.