### PR TITLE
Add ticket-id-complement input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,10 +29,10 @@ inputs:
     description: '[Internal] The location to store the mutex repo'
     required: false
     default: '/run/gh-action-mutex/repo'
-  ticket-id-complement:
+  ticket-id-suffix:
     description: 'Ticket id suffix to avoid identical values for parallel/matrix jobs in the same workflow run'
     required: false
-    default: ''
+    default: 'default'
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -43,7 +43,7 @@ runs:
     ARG_REPOSITORY: ${{ inputs.repository }}
     ARG_REPO_TOKEN: ${{ inputs.repo-token }}
     ARG_DEBUG: ${{ inputs.debug }}
-    ARG_TICKET_ID_COMPLEMENT: ${{ inputs.ticket-id-complement}}
+    ARG_TICKET_ID_SUFFIX: ${{ inputs.ticket-id-suffix}}
   entrypoint: '/scripts/lock.sh'
   post-entrypoint: '/scripts/unlock.sh'
 

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,10 @@ inputs:
     description: '[Internal] The location to store the mutex repo'
     required: false
     default: '/run/gh-action-mutex/repo'
+  ticket-id-complement:
+    description: 'Ticket id suffix to avoid identical values for parallel/matrix jobs in the same workflow run'
+    required: false
+    default: ''
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -39,6 +43,7 @@ runs:
     ARG_REPOSITORY: ${{ inputs.repository }}
     ARG_REPO_TOKEN: ${{ inputs.repo-token }}
     ARG_DEBUG: ${{ inputs.debug }}
+    ARG_TICKET_ID_COMPLEMENT: ${{ inputs.ticket-id-complement}}
   entrypoint: '/scripts/lock.sh'
   post-entrypoint: '/scripts/unlock.sh'
 

--- a/rootfs/scripts/lock.sh
+++ b/rootfs/scripts/lock.sh
@@ -15,7 +15,7 @@ cd "$ARG_CHECKOUT_LOCATION"
 
 __mutex_queue_file=mutex_queue
 __repo_url="https://x-access-token:$ARG_REPO_TOKEN@$ARG_GITHUB_SERVER/$ARG_REPOSITORY"
-__ticket_id="$GITHUB_RUN_ID-$(date +%s)-$(( $RANDOM % 1000 ))"
+__ticket_id="$GITHUB_RUN_ID-$(date +%s)-$(( $RANDOM % 1000 ))-$ARG_TICKET_ID_COMPLEMENT"
 echo "ticket_id=$__ticket_id" >> $GITHUB_STATE
 
 set_up_repo "$__repo_url"

--- a/rootfs/scripts/lock.sh
+++ b/rootfs/scripts/lock.sh
@@ -15,7 +15,7 @@ cd "$ARG_CHECKOUT_LOCATION"
 
 __mutex_queue_file=mutex_queue
 __repo_url="https://x-access-token:$ARG_REPO_TOKEN@$ARG_GITHUB_SERVER/$ARG_REPOSITORY"
-__ticket_id="$GITHUB_RUN_ID-$(date +%s)-$(( $RANDOM % 1000 ))-$ARG_TICKET_ID_COMPLEMENT"
+__ticket_id="$GITHUB_RUN_ID-$(date +%s)-$(( $RANDOM % 1000 ))-$ARG_TICKET_ID_SUFFIX"
 echo "ticket_id=$__ticket_id" >> $GITHUB_STATE
 
 set_up_repo "$__repo_url"


### PR DESCRIPTION
Add ticket-id-complement input to avoid identical ticket_id value for parallel/matrix jobs in the same workflow run.

Motivation: Parallel/Matrix jobs could generate the same ticket_id, meaning multiple parallel jobs in the same workflow run could gain access to a resource at the same time. The new input allows adding a suffix to the ticket_id, allowing different values being generated for different jobs.

Resolves #32 